### PR TITLE
 box-highlight thing around search is no more

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,3 +51,6 @@ input {
     text-align: center;
     margin-bottom: 50px;
 }
+input:focus {
+    outline: none;
+}


### PR DESCRIPTION
i saw your post on r/unixporn and took some of your code for my homepage's search bar. i noticed the search bar gets highlighted with an outline and wanted to remove it since it felt like it didnt go with the theme. so i made this change in my version and thought you might like it too :)